### PR TITLE
Prevent a useless pass in the Watt constructor by using an instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function wrap (gen, opts) {
       args = args.slice(0, -1)
     }
     if (!opts.context) opts.context = this
-    return Watt(gen, args, opts, cb).run()
+    return new Watt(gen, args, opts, cb).run()
   }
 }
 


### PR DESCRIPTION
Otherwise, all calls on `watt(function*(){})` enters two times in the Watt
function.

---

Please @mappum, merge because it's really annoying when debugging (step into) and I use watt everywhere in my projects. Thanks

Regards